### PR TITLE
accommodate Consul 1.14.0 gRPC changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -465,6 +465,11 @@ in many Ansible versions, so this feature might not always work.
   assumes consul default ports etc.
 - Default value: **False**
 
+### `nomad_consul_version`
+
+- The version of consul used in native consul zero-configuration
+- Default value: **1.13.2**
+
 ### `nomad_consul_address`
 
 - The address of your consul API, use it in combination with nomad_use_consul=True. If you want to use https, use `nomad_consul_ssl`. Do NOT append https.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -152,6 +152,7 @@ nomad_gather_server_facts: false
 
 ### Consul
 nomad_use_consul: false
+nomad_consul_version: "{{ lookup('env','CONSUL_VERSION') | default('1.13.2', true) }}"
 nomad_consul_address: "localhost:8500"
 nomad_consul_ssl: false
 nomad_consul_ca_file: ""

--- a/templates/base.hcl.j2
+++ b/templates/base.hcl.j2
@@ -23,7 +23,9 @@ consul {
     # The address to the Consul agent.
     address = "{{ nomad_consul_address }}"
     ssl = {{ nomad_consul_ssl | bool | lower }}
+{% if nomad_consul_version | version('1.14.0', '>=') %}
     grpc_ca_file = "{{ nomad_consul_ca_file }}"
+{% endif %}
     ca_file = "{{ nomad_consul_ca_file }}"
     cert_file = "{{ nomad_consul_cert_file }}"
     key_file = "{{ nomad_consul_key_file }}"

--- a/templates/base.hcl.j2
+++ b/templates/base.hcl.j2
@@ -23,6 +23,7 @@ consul {
     # The address to the Consul agent.
     address = "{{ nomad_consul_address }}"
     ssl = {{ nomad_consul_ssl | bool | lower }}
+    grpc_ca_file = "{{ nomad_consul_ca_file }}"
     ca_file = "{{ nomad_consul_ca_file }}"
     cert_file = "{{ nomad_consul_cert_file }}"
     key_file = "{{ nomad_consul_key_file }}"


### PR DESCRIPTION
See:
 - Consul Connect sidecar proxies require additional configuration for gRPC-TLS listener - https://github.com/hashicorp/nomad/issues/15360
 - client: accommodate Consul 1.14.0 gRPC and agent self changes - https://github.com/hashicorp/nomad/pull/15309
 - consul: add client configuration for grpc_ca_file - https://github.com/hashicorp/nomad/pull/15701
 - Fix issue where TLS configuration was ignored for unix sockets in consul connect envoy. - https://github.com/hashicorp/consul/pull/15913
 - Envoy -> consul “upstream connect error or disconnect/reset before headers. reset reason: connection termination” - https://discuss.hashicorp.com/t/envoy-consul-upstream-connect-error-or-disconnect-reset-before-headers-reset-reason-connection-termination/48303